### PR TITLE
fix: embed HTML directly for event descriptions

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -38,7 +38,8 @@
           <v-card-title>{{selectedEvent.event.summary}}</v-card-title>
           <v-card-subtitle>{{ selectedEvent.date | moment('MMMM Do YYYY, h:mma Z') }}, which is maybe {{ selectedEvent.date | moment("from", "now") }}</v-card-subtitle>
           <v-card-text>
-	    {{ selectedEvent.event.description }}
+          <div :v-html="selectedEvent.event.description">
+          </div>
           </v-card-text>
           <v-list one-line>
             <v-list-item v-if="selectedEvent.event.attendees.length > 0">


### PR DESCRIPTION
Vue escapes any HTML inside `{{ }}`, so we use `v-html` to solve this. (I haven't tested this, just made the quick fix on Github.)

The issue: 
![image](https://user-images.githubusercontent.com/65318685/124205014-32ab4700-da95-11eb-836a-6b4083907c2c.png)


The fix is to inject the description via `:v-html`.