### PR TITLE
Streamline Calendar Info Box

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -37,7 +37,7 @@
       <v-col style="height: calc(100vh - 104px);position:sticky;top:0"  cols="3">
         <v-card  v-if="selectedEvent">
           <v-card-title>{{selectedEvent.event.summary}}</v-card-title>
-          <v-card-subtitle>{{ selectedEvent.date | moment('MMMM Do YYYY, h:mma Z') }}, which is maybe {{ selectedEvent.date | moment("from", "now") }}</v-card-subtitle>
+          <v-card-subtitle>{{ selectedEvent.date | correctTense }} {{selectedEvent.date | moment("from", "now") }} (time zone: {{selectedEvent.date | moment('[UTC]Z')}})</v-card-subtitle>
           <v-card-text>
 	    <div v-html="selectedEvent.event.description">
 	    </div>
@@ -69,7 +69,7 @@
               </v-list-item-icon>
 
               <v-list-item-content>
-                <v-list-item-title>{{ selectedEvent.date | moment('MMMM Do YYYY, h:mma Z') }}</v-list-item-title>
+                <v-list-item-title>{{ selectedEvent.date | moment('MMMM Do YYYY, h:mma') }}</v-list-item-title>
               </v-list-item-content>
             </v-list-item>
 
@@ -237,6 +237,12 @@ export default {
       calendarValue: '',
       ready: false,
     };
+  },
+
+  filters: {
+    correctTense(value) {
+        return moment(value).isBefore(moment()) ? 'Happened' : 'Happening';
+    },
   },
 
   methods: {


### PR DESCRIPTION
I made some minor changes to Calendar.vue to streamline the information displayed.

- The date is displayed both in the subtitle and the date field, I took it out of the subtitle because that's redundant
- The time zone is displayed in two place, I left it in the subtitle and not the date field.
  - Added "UTC" before the "-XX:XX" part because a random minus sign being there alone looks weird
  - Removed "maybe" from subtitle: it should be confident!
 - At first I didn't want to add a filter, but I ended up making one anyways, it basically just changes the "Happening" [in x days] to "Happened" [x days ago] so everything looks natural.

This has the added benefit of making the line short enough to not wrap for the last few words in the information card, which has been bugging me for some time. Also note that Saumya told me how to put stuff in my .env so I could login for testing: she told me to tell you that just so you were aware.

Once again, just some minor things, but it's been bugging me for some time and fixing definitely will take one more annoyance away! Sorry taking such a long time and not adding more, I'm trying to focus on the math for the most part.